### PR TITLE
Sequential write for larger domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Export SimpleDB domain from us-west-1:
 sdbport export -k $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -r us-west-1 -n data -o /tmp/test-domain-dump
 ```
 
+Export larger SimpleDB domain from us-west-1 - writes each chunk to file as it is received rather than storing in memory:
+
+```
+sdbport export -k $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -r us-west-1 -n data -o /tmp/test-domain-dump -w yes
+```
+
 Import into domain in us-east-1
 
 ```

--- a/lib/sdbport/aws/simpledb.rb
+++ b/lib/sdbport/aws/simpledb.rb
@@ -35,6 +35,17 @@ module Sdbport
         end
       end
 
+      def select_and_store_tokens(query, options = {})
+        options.merge! 'NextToken' => @next_token
+        chunk = sdb.select(query, options).body
+        @next_token = chunk['NextToken']
+        return chunk['Items']
+      end
+
+      def no_more_chunks?
+        @next_token.nil?
+      end
+
       def count(domain)
         body = sdb.select("SELECT count(*) FROM `#{domain}`").body
         body['Items']['Domain']['Count'].first.to_i

--- a/lib/sdbport/cli/export.rb
+++ b/lib/sdbport/cli/export.rb
@@ -19,7 +19,12 @@ module Sdbport
                             :access_key => access_key,
                             :secret_key => secret_key,
                             :logger     => logger
-        exit 1 unless domain.export opts[:output]
+
+        if opts[:write_as_you_go]
+          exit 1 unless domain.export_sequential_write opts[:output]
+        else
+          exit 1 unless domain.export opts[:output]
+        end
       end
 
       def read_options
@@ -44,6 +49,7 @@ EOS
           opt :access_key, "AWS Access Key ID", :type  => :string,
                                                 :short => 'k'
           opt :secret_key, "AWS Secret Access Key", :type => :string
+          opt :write_as_you_go, "Write chunks as they are received from Simple DB", :type => :string
         end
       end
     end

--- a/lib/sdbport/domain.rb
+++ b/lib/sdbport/domain.rb
@@ -18,6 +18,10 @@ module Sdbport
       domain_export.export output
     end
 
+    def export_sequential_write(output)
+      domain_export.export_sequential_write output
+    end
+
     def purge
       domain_purge.purge
     end

--- a/lib/sdbport/domain/export.rb
+++ b/lib/sdbport/domain/export.rb
@@ -22,6 +22,22 @@ module Sdbport
         return true if file.close.nil?
       end
 
+      def export_sequential_write(output)
+        puts "using sequential\n"
+        # setup file
+        @logger.info "Export #{@name} in #{@region} to #{output}"
+        file = File.open(output, 'w')
+
+        while true
+          export_domain_w_sequential_write.each do |item| 
+            file.write convert_to_string item
+            file.write "\n"
+          end
+          break if sdb.no_more_chunks?
+        end
+        return true if file.close.nil?
+      end
+
       private
 
       def sdb
@@ -32,6 +48,10 @@ module Sdbport
 
       def export_domain
         sdb.select_and_follow_tokens "select * from `#{@name}`"
+      end
+
+      def export_domain_w_sequential_write
+        sdb.select_and_store_tokens "select * from `#{@name}`"
       end
 
       def convert_to_string(item)


### PR DESCRIPTION
I've added support for writing the chunks out to file as they are pulled down from SimpleDB. We have some domains that have well over 1MM records and keeping that in memory was proving problematic.

I've added a command line argument (-w) that allows you to enable this mode - updates to the readme show how to use this feature.

I also included a correction to the readme; using -k for the aws key rather than -a, which is not used for app credentials.
